### PR TITLE
feat(listing): add create listing endpoint

### DIFF
--- a/backend/cdk/bin/app.ts
+++ b/backend/cdk/bin/app.ts
@@ -1,7 +1,21 @@
-import * as cdk from 'aws-cdk-lib';
+import { App, Stack, StackProps } from 'aws-cdk-lib';
 import { UserStack } from '../lib/user-stack';
+import { ListingStack } from '../lib/listing-stack';
 
-const app = new cdk.App();
-new UserStack(app, 'UserStack', {
-    env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-});
+class MainStack extends Stack {
+    constructor(scope: App, id: string, props?: StackProps) {
+        super(scope, id, props);
+
+        const userStack = new UserStack(this, 'UserStack');
+
+        new ListingStack(this, 'ListingStack', {
+            userPoolId: userStack.userPoolId,
+            userPoolClientId: userStack.userPoolClientId,
+            hostGroup: userStack.hostGroup,
+        });
+    }
+}
+
+const app = new App();
+new MainStack(app, 'MainStack');
+app.synth();

--- a/backend/cdk/lib/listing-stack.ts
+++ b/backend/cdk/lib/listing-stack.ts
@@ -1,0 +1,69 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+
+interface ListingStackProps extends cdk.StackProps {
+    userPoolId: string;
+    userPoolClientId: string;
+    hostGroup: string;
+}
+
+export class ListingStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props: ListingStackProps) {
+        super(scope, id, props);
+
+        // Create DynamoDB tables
+        const experienceTable = new dynamodb.Table(this, 'ExperienceTable', {
+            partitionKey: { name: 'listingId', type: dynamodb.AttributeType.STRING },
+            billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+        });
+
+        const stayTable = new dynamodb.Table(this, 'StayTable', {
+            partitionKey: { name: 'listingId', type: dynamodb.AttributeType.STRING },
+            billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+        });
+
+        // Create Lambda function for creating listing
+        const createListingFunction = new lambda.Function(this, 'CreateListingFunction', {
+            runtime: lambda.Runtime.NODEJS_14_X,
+            handler: 'listing/create.handler',
+            code: lambda.Code.fromAsset('src/listing'),
+            environment: {
+                EXPERIENCE_TABLE_NAME: experienceTable.tableName,
+                STAY_TABLE_NAME: stayTable.tableName,
+                USER_POOL_ID: props.userPoolId,
+                HOST_GROUP: props.hostGroup,
+            },
+        });
+
+        experienceTable.grantReadWriteData(createListingFunction);
+        stayTable.grantReadWriteData(createListingFunction);
+
+        createListingFunction.addToRolePolicy(new PolicyStatement({
+            actions: [
+                'cognito-idp:GetUser',
+                'cognito-idp:AdminAddUserToGroup'
+            ],
+            resources: [`arn:aws:cognito-idp:*:*:userpool/${props.userPoolId}`],
+        }));
+
+        // Create API Gateway
+        const api = new apigateway.RestApi(this, 'ListingApi', {
+            restApiName: 'Listing Service',
+        });
+
+        const listings = api.root.addResource('listings');
+        const createListing = listings.addResource('create');
+        const createListingIntegration = new apigateway.LambdaIntegration(createListingFunction);
+        createListing.addMethod('POST', createListingIntegration);
+
+        // Output the table names
+        new cdk.CfnOutput(this, 'ExperienceTableName', { value: experienceTable.tableName });
+        new cdk.CfnOutput(this, 'StayTableName', { value: stayTable.tableName });
+    }
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@aws-sdk/client-cognito-identity-provider": "^3.614.0",
         "@aws-sdk/client-dynamodb": "^3.614.0",
         "@aws-sdk/lib-dynamodb": "^3.614.0",
+        "@types/uuid": "^10.0.0",
         "aws-cdk-lib": "2.0.0-rc.33",
         "aws-lambda": "^1.0.7",
         "constructs": "^10.0.0",
@@ -3930,6 +3931,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.19",
@@ -16326,6 +16332,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "@types/yargs": {
       "version": "15.0.19",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "lint": "eslint 'src/**/*.{ts,tsx}'"
+    "lint": "eslint '{src,cdk}/**/*.{ts,tsx}'"
   },
   "devDependencies": {
     "@eslint/js": "^9.6.0",
@@ -38,6 +38,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.614.0",
     "@aws-sdk/client-dynamodb": "^3.614.0",
     "@aws-sdk/lib-dynamodb": "^3.614.0",
+    "@types/uuid": "^10.0.0",
     "aws-cdk-lib": "2.0.0-rc.33",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",

--- a/backend/src/listing/create.ts
+++ b/backend/src/listing/create.ts
@@ -1,0 +1,92 @@
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { CognitoIdentityProviderClient, GetUserCommand, AdminAddUserToGroupCommand } from '@aws-sdk/client-cognito-identity-provider';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { v4 as uuidv4 } from 'uuid';
+
+const cognitoClient = new CognitoIdentityProviderClient({});
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+const EXPERIENCE_TABLE = process.env.EXPERIENCE_TABLE_NAME || '';
+const STAY_TABLE = process.env.STAY_TABLE_NAME || '';
+const HOST_GROUP = process.env.HOST_GROUP || '';
+
+export const handler: APIGatewayProxyHandler = async (event) => {
+    const token = event.headers.Authorization || '';
+    const body = JSON.parse(event.body || '{}');
+
+    if (!token) {
+        return {
+            statusCode: 401,
+            body: JSON.stringify({ message: 'Missing authorization token' }),
+        };
+    }
+
+    let userId: string | undefined;
+    let userGroups: string[] = [];
+
+    try {
+        // Verify token by calling Cognito
+        const getUserCommand = new GetUserCommand({ AccessToken: token });
+        const userResponse = await cognitoClient.send(getUserCommand);
+
+        if (!userResponse.UserAttributes) {
+            throw new Error('User attributes not found');
+        }
+
+        userId = userResponse.UserAttributes.find(attr => attr.Name === 'sub')?.Value;
+
+        if (!userId) {
+            throw new Error('User ID not found in token');
+        }
+
+        // Check user groups
+        const groupsAttribute = userResponse.UserAttributes.find(attr => attr.Name === 'cognito:groups');
+        if (groupsAttribute && groupsAttribute.Value) {
+            userGroups = groupsAttribute.Value.split(',');
+        }
+
+        // If user is not in host group, add them
+        if (!userGroups.includes(HOST_GROUP)) {
+            const addUserToGroupCommand = new AdminAddUserToGroupCommand({
+                GroupName: HOST_GROUP,
+                UserPoolId: process.env.USER_POOL_ID || '',
+                Username: userId,
+            });
+            await cognitoClient.send(addUserToGroupCommand);
+        }
+    } catch (error) {
+        return {
+            statusCode: 403,
+            body: JSON.stringify({ message: 'Invalid token', error: error.message }),
+        };
+    }
+
+    const { listingType, ...rest } = body;
+    const listingId = uuidv4();
+    const newListing = {
+        ...rest,
+        listingId,
+        hostId: userId,
+    };
+
+
+    try {
+        const tableName = listingType === 'experience' ? EXPERIENCE_TABLE : STAY_TABLE;
+        await docClient.send(new PutCommand({
+            TableName: tableName,
+            Item: newListing,
+        }));
+
+        return {
+            statusCode: 201,
+            body: JSON.stringify({ message: 'Listing created successfully', listingId }),
+        };
+    } catch (error) {
+        return {
+            statusCode: 500,
+            body: JSON.stringify({ message: 'Could not create listing', error: error.message }),
+        };
+    }
+};


### PR DESCRIPTION
- Added support for creating listings with listingType 'experience' or 'stay'
- Verified user token and ensured user is in host group before creating listing
- Spread body object excluding listingType before creating new listing
- Stored listing in appropriate DynamoDB table based on listingType

Changes:
- lib/listing-stack.ts: defined resources and API integration
- src/listing/create.ts: implemented Lambda function for creating listings with proper Cognito validation and handling listingType